### PR TITLE
Fix quantile normalization for EBSeq.

### DIFF
--- a/R/generateRmdCodeDiffExp.R
+++ b/R/generateRmdCodeDiffExp.R
@@ -54,7 +54,7 @@ EBSeq.createRmd <- function(data.path, result.path, codefile,
   if (norm.method == "median") {
     writeLines("sizes <- MedianNorm(count.matrix(cdata))", codefile)
   } else if (norm.method == "quantile") {
-    writeLines("sizes <- QuantileNorm(count.matrix(cdata))", codefile)
+    writeLines("sizes <- QuantileNorm(count.matrix(cdata), .75)", codefile)
   }
   writeLines(c("EBSeq.test <- EBTest(Data = count.matrix(cdata), Conditions = factor(sample.annotations(cdata)$condition), sizeFactors = sizes, maxround = 10)", 
                "EBSeq.ppmat <- GetPPMat(EBSeq.test)", 


### PR DESCRIPTION
Hi Charlotte,

compcodeR is great; I'm in the middle of swapping something I wrote to do the same thing over to using compcodeR instead.

Without explicitly setting the quantile to normalize EBSeq was silently not returning anything with quantile normalization turned on.
