### PR TITLE
Fix phylolm.factor fail on windows

### DIFF
--- a/tests/testthat/test-runComparison.R
+++ b/tests/testthat/test-runComparison.R
@@ -1299,7 +1299,7 @@ test_that("runDiffExp works - phylo", {
     result.extent = "phylolm.factor",
     Rmdfunction = "phylolm.createRmd",
     output.directory = tdir, norm.method = "TMM",
-    model = "BM", measurement_error = FALSE,
+    model = "BM", measurement_error = TRUE,
     extra.design.covariates = c("test_reg", "test_fac"),
     length.normalization = "TPM",
     data.transformation = "log2"
@@ -1338,9 +1338,7 @@ test_that("runDiffExp works - phylo", {
     }
   }
 
-  ## For some reason, generateCodeHTMLs with phylolm.factor causes problems
-  ## (invalid file name?) on Windows
-  for (m in setdiff(methods, "phylolm.factor")) {
+  for (m in methods) {
     if (!(m %in% c("DESeq2.length", "DESeq2.length.factor")) || requireNamespace("DESeq2", quietly = TRUE)) {
       if (!(m %in% c("lengthNorm.limma.cor")) || requireNamespace("statmod", quietly = TRUE)) {
         if (!(m %in% c("lengthNorm.sva.limma", "lengthNorm.sva.limma.factor")) || requireNamespace("sva", quietly = TRUE)) {


### PR DESCRIPTION
When "measurement_error = FALSE", phylolm becomes unstable for this kind of trees.
This caused many errors in the fits. Setting it to TRUE seems to fix the error.

I'm still not sure to understand however why it caused an error specifically on Windows, and not other platforms.

I already noticed that, when the analysis fails for one reason or an other, instead of an explicit error message we get this strange error message about an invalid file name. The only way to debug those for me is to generate the HTML code and check what went wrong (which is what I did here). But maybe we could think of a way to get more explicit error messages in these cases ?

This seems to fix the test part, but new errors with the BiocCheck appeared (on all platforms).
I'm not sure they are related ?